### PR TITLE
delete duplicated date format in print_datetime_help

### DIFF
--- a/main.c
+++ b/main.c
@@ -84,7 +84,6 @@ void print_datetime_help()
 "The following date representations are understood: \n"
 "DD/MM/YYYY\n"
 "DD/MM\n"
-"DD/MM/YYYY\n"
 "month_name DD YYYY\n"
 "month_name DD\n"
 "DDD#YYYY            (day of year, 1-366; for use in scripts)\n"


### PR DESCRIPTION
Hello, i found a duplication in the string printed by --datetime help.
Fixed it in this commit.